### PR TITLE
Allow WooImport jobs to retry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
-    net-imap (0.5.1)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -488,7 +488,7 @@ GEM
     thruster (0.1.9-arm64-darwin)
     thruster (0.1.9-x86_64-darwin)
     thruster (0.1.9-x86_64-linux)
-    timeout (0.4.2)
+    timeout (0.4.3)
     trailblazer-option (0.1.2)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -685,7 +685,7 @@ CHECKSUMS
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   net-http (0.6.0) sha256=9621b20c137898af9d890556848c93603716cab516dc2c89b01a38b894e259fb
-  net-imap (0.5.1) sha256=c0ceb85d8459f7081d5ed1ac86159f8e80d25e704eb52dbf0d9f703b7bc838d7
+  net-imap (0.5.6) sha256=1ede8048ee688a14206060bf37a716d18cb6ea00855f6c9b15daee97ee51fbe5
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.0) sha256=5fc0415e6ea1cc0b3dfea7270438ec22b278ca8d524986a3ae4e5ae8d087b42a
@@ -770,7 +770,7 @@ CHECKSUMS
   thruster (0.1.9-arm64-darwin) sha256=a5bb7e636df5e1a50ca5bd7e3301f9af5caff00d6b5479379d4ecb79e918bed6
   thruster (0.1.9-x86_64-darwin) sha256=c9f081af2065b04cccba3f55fea8ac8ec79ee9488e08d9139e1bf6b94faa4ae6
   thruster (0.1.9-x86_64-linux) sha256=86175171fff8c984861fb73591c32d294b5aad67e6b95a6575ffa6c2ab0a7f19
-  timeout (0.4.2) sha256=8aca2d5ff98eb2f7a501c03f8c3622065932cc58bc58f725cd50a09e63b4cc19
+  timeout (0.4.3) sha256=9509f079b2b55fe4236d79633bd75e34c1c1e7e3fb4b56cb5fda61f80a0fe30e
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   turbo-rails (2.0.11) sha256=fc47674736372780abd2a4dc0d84bef242f5ca156a457cd7fa6308291e397fcf
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b

--- a/app/jobs/woocommerce_import_job.rb
+++ b/app/jobs/woocommerce_import_job.rb
@@ -1,7 +1,11 @@
 class WoocommerceImportJob < ApplicationJob
   queue_as :default
+  sidekiq_options retry: true
 
   def perform(*args)
     WooImport.new.poll_jobs
+  rescue StandardError => e
+    WooImport.where(type: "WOO_IMPORT", status: :processing).order(updated_at: :desc).first.status_error!
+    raise e
   end
 end

--- a/app/jobs/woocommerce_import_job.rb
+++ b/app/jobs/woocommerce_import_job.rb
@@ -4,7 +4,7 @@ class WoocommerceImportJob < ApplicationJob
 
   def perform(*args)
     WooImport.new.poll_jobs
-  rescue StandardError => e
+  rescue => e
     WooImport.where(type: "WOO_IMPORT", status: :processing).order(updated_at: :desc).first.status_error!
     raise e
   end

--- a/app/services/woo_import.rb
+++ b/app/services/woo_import.rb
@@ -54,7 +54,7 @@ class WooImport
       WoocommerceImportJob.set(wait: 5.minutes).perform_later
       return
     end
-    jobs = Job.where(type: "WOO_IMPORT", status: [:created, :paused]).all
+    jobs = Job.where(type: "WOO_IMPORT", status: [:created, :paused, :error]).all
     if jobs.count == 0
       Rails.logger.info "POLLING: No WOO_IMPORT jobs found."
       return


### PR DESCRIPTION
This should make it so that if a WooImport job fails, it will retry per the standard sidekiq retry protocol.