### PR TITLE
Removed unnecessary SKU's from SFImport inventory results.

### DIFF
--- a/app/services/s_f_import.rb
+++ b/app/services/s_f_import.rb
@@ -185,9 +185,15 @@ class SFImport
       end
     end
     inventory = []
+    skus = filter_skus(skus)
     skus.each do |sku, quantity|
       inventory << {sku:, quantity:}
     end
+    filter_inventory(inventory)
+  end
+
+  def filter_skus(skus)
+    skus.filter { |sku, _quantity| sku != "MSC17061" && sku != "COL20277" }
   end
 
   def is_bundle?(sku, products)

--- a/app/services/s_f_import.rb
+++ b/app/services/s_f_import.rb
@@ -185,11 +185,10 @@ class SFImport
       end
     end
     inventory = []
-    skus = filter_skus(skus)
-    skus.each do |sku, quantity|
+    filtered_skus = filter_skus(skus)
+    filtered_skus.each do |sku, quantity|
       inventory << {sku:, quantity:}
     end
-    filter_inventory(inventory)
   end
 
   def filter_skus(skus)

--- a/spec/services/s_f_import_spec.rb
+++ b/spec/services/s_f_import_spec.rb
@@ -17,7 +17,7 @@ describe SFImport do
     LightspeedStubHelpers.stub_lightspeed_account_request
   end
 
-  it('should filter special orders (MSC17061) and collateral (COL20277) out of inventory') do
+  it("should filter special orders (MSC17061) and collateral (COL20277) out of inventory") do
     skus = {}
     skus["TEST0"] = 1
     skus["MSC17061"] = 1

--- a/spec/services/s_f_import_spec.rb
+++ b/spec/services/s_f_import_spec.rb
@@ -25,10 +25,10 @@ describe SFImport do
     skus["TEST1"] = 1
     skus = sfi.filter_skus skus
     expect skus.keys.count == 2
-    expect skus.keys.include?("MSC17061") == false
-    expect skus.keys.include?("COL20277") == false
-    expect skus.keys.include?("TEST0") == true
-    expect skus.keys.include?("TEST1") == true
+    expect skus.key?("MSC17061") == false
+    expect skus.key?("COL20277") == false
+    expect skus.key?("TEST0") == true
+    expect skus.key?("TEST1") == true
   end
 
   xit("should create a new job") do

--- a/spec/services/s_f_import_spec.rb
+++ b/spec/services/s_f_import_spec.rb
@@ -2,15 +2,35 @@ require "rails_helper"
 require "json"
 
 describe SFImport do
-  before do
-    SFImport.new
-    LightspeedApiHelper.new
+  let(:sfi) { SFImport.new }
+  let(:lsh) { LightspeedApiHelper.new }
 
-    woo = WooRefresh.new
-    if woo.latest_refresh_timestamp.nil? || woo.latest_refresh_timestamp < 1.day.ago
-      puts "Woo cache is stale, refreshing..."
-      woo.handle_job woo.create_job
-    end
+  before do
+    shop = double("shop")
+    allow_any_instance_of(LightspeedApiHelper).to receive(:find_shop).and_return(shop)
+    allow(shop).to receive("Contact").and_return({"custom" => "random_event_code"})
+
+    create_list(:woo_product, 401)
+
+    allow_any_instance_of(WooRefresh).to receive(:latest_refresh_timestamp).and_return(1.hour.ago)
+    allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(nil)
+    LightspeedStubHelpers.stub_lightspeed_account_request
+  end
+
+  it('should filter special orders (MSC17061) and collateral (COL20277) out of inventory') do
+    job = SFImport.new.create_job 36, "2025-02-06", "2025-02-12"
+    sales = JSON.parse(File.read("#{Rails.root}/spec/fixtures/2025.02.05.grand_rapids.json"))
+    skus = {}
+    skus["TEST0"] = 1
+    skus["MSC17061"] = 1
+    skus["COL20277"] = 1
+    skus["TEST1"] = 1
+    skus = sfi.filter_skus skus
+    expect skus.keys.count == 2
+    expect skus.keys.include?("MSC17061") == false
+    expect skus.keys.include?("COL20277") == false
+    expect skus.keys.include?("TEST0") == true
+    expect skus.keys.include?("TEST1") == true
   end
 
   xit("should create a new job") do

--- a/spec/services/s_f_import_spec.rb
+++ b/spec/services/s_f_import_spec.rb
@@ -18,8 +18,6 @@ describe SFImport do
   end
 
   it('should filter special orders (MSC17061) and collateral (COL20277) out of inventory') do
-    job = SFImport.new.create_job 36, "2025-02-06", "2025-02-12"
-    sales = JSON.parse(File.read("#{Rails.root}/spec/fixtures/2025.02.05.grand_rapids.json"))
     skus = {}
     skus["TEST0"] = 1
     skus["MSC17061"] = 1


### PR DESCRIPTION
This PR removes the SKU's that Tim found problematic. Chad confirmed that they should not be included in the report that goes to SalesForce anyway.