### PR TITLE
Run sidekiq-cron poller in the web process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,8 +98,8 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     amazing_print (1.6.0)
     ast (2.4.3)
-    auth-sanitizer (0.2.0)
-      version_gem (~> 1.1, >= 1.1.9)
+    auth-sanitizer (0.2.1)
+      version_gem (~> 1.1, >= 1.1.10)
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (4.0.1)
@@ -291,15 +291,15 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    oauth2 (2.0.20)
-      auth-sanitizer (~> 0.1, >= 0.1.3)
+    oauth2 (2.0.22)
+      auth-sanitizer (~> 0.2, >= 0.2.1)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.4)
-      version_gem (~> 1.1, >= 1.1.9)
+      snaky_hash (~> 2.0, >= 2.0.5)
+      version_gem (~> 1.1, >= 1.1.11)
     oj (3.16.7)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
@@ -487,7 +487,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    snaky_hash (2.0.4)
+    snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     solid_cache (1.0.6)
@@ -528,7 +528,7 @@ GEM
     unicode-emoji (4.1.0)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.10)
+    version_gem (1.1.11)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -628,7 +628,7 @@ CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   amazing_print (1.6.0) sha256=9903e93daadc15411c854239f8ca1ca6ce78be279ed99d43fec2bd3b0aa37397
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  auth-sanitizer (0.2.0) sha256=3b9763c1156546a5982d5d71a7904fb292a14ca2b9bd3f959061f22d732b60a0
+  auth-sanitizer (0.2.1) sha256=917dcf01f7589b06c26726afe90568cf2fb29d37a1f94facfc664f11967cc577
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
@@ -729,7 +729,7 @@ CHECKSUMS
   nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
   nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
   nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
-  oauth2 (2.0.20) sha256=790c6316346da12f9dcaf27a67530f802950af05d35c3874918da84f2deae674
+  oauth2 (2.0.22) sha256=8f4669f0c8de69f6db7ed786bda20996eaf0003966b886f1c519efb1a5682fa6
   oj (3.16.7) sha256=f199c24dbc8fbb1afc01f8be443b8ae0440c0fc4c7a5ca0d898199d0c8e4013d
   omniauth (2.1.2) sha256=def03277298b8f8a5d3ff16cdb2eb5edb9bffed60ee7dda24cc0c89b3ae6a0ce
   omniauth-oauth2 (1.8.0) sha256=b2f8e9559cc7e2d4efba57607691d6d2b634b879fc5b5b6ccfefa3da85089e78
@@ -796,7 +796,7 @@ CHECKSUMS
   simplecov-cobertura (3.1.0) sha256=6d7f38aa32c965ca2174b2e5bd88cb17138eaf629518854976ac50e628925dc5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
-  snaky_hash (2.0.4) sha256=2b12758c57defa6796341a1620f84b1a23737421d8d7e2575d0550b53cc4fece
+  snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a
   solid_cache (1.0.6) sha256=fe1acf73fbe4a6a53620425317949082d3b99e0cfd35416106b56220fa66c311
   standard (1.51.1) sha256=6d0d98a1fac26d660393f37b3d9c864632bb934b17abfa23811996b20f87faf2
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
@@ -819,7 +819,7 @@ CHECKSUMS
   unicode-emoji (4.1.0) sha256=4997d2d5df1ed4252f4830a9b6e86f932e2013fbff2182a9ce9ccabda4f325a5
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
-  version_gem (1.1.10) sha256=d0575dc9f2949b2db9497051f96e5c36d7c6c2f2e81afd1a73cacccd4690e506
+  version_gem (1.1.11) sha256=695df6464862b3dc976b4f6e0e089062517c8137ecd31078d8c378347f959c97
   web-console (4.2.1) sha256=e7bcf37a10ea2b4ec4281649d1cee461b32232d0a447e82c786e6841fd22fe20
   webmock (3.24.0) sha256=be01357f6fc773606337ca79f3ba332b7d52cbe5c27587671abc0572dbec7122
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -39,3 +39,37 @@ plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+
+# Keep sidekiq-cron polling alive in the always-on web process.
+#
+# sidekiq-cron starts its poller only inside Sidekiq *workers* — it patches the
+# Sidekiq server Launcher from within a Sidekiq.configure_server block, which
+# never runs in Puma. But sidekiq-foreman scales the Sidekiq worker fleet to
+# desiredCount=0 when the queues are idle, and with zero workers there is no
+# poller, so cron jobs silently stop enqueuing and never fire.
+#
+# Running a poller here, in the always-on web container, keeps cron jobs
+# enqueuing regardless of worker count; once a job lands in a queue the foreman
+# scales workers back up to run it. Safe to run alongside the workers' own
+# poller: sidekiq-cron gates each occurrence on an atomic Redis ZADD, so no job
+# is enqueued twice. Background: CruGlobal/sidekiq-foreman docs/sidekiq-cron-web-poller.md
+#
+# NOTE: Puma runs in single mode here (no `workers` directive). If clustering is
+# ever enabled (WEB_CONCURRENCY), move this to `on_worker_boot` so the poller
+# starts in each forked worker rather than the master.
+on_booted do
+  unless Rails.env.development? || Rails.env.test?
+    begin
+      require "sidekiq/cron"
+      # Mirror sidekiq-cron's server Launcher: copy the poll interval onto the
+      # config the poller reads (Poller#poll_interval_average returns
+      # config[:cron_poll_interval] with no fallback).
+      config = Sidekiq.default_configuration
+      config[:cron_poll_interval] = Sidekiq::Cron.configuration.cron_poll_interval.to_i
+      Sidekiq::Cron::Poller.new(config).start
+      Rails.logger.info("[sidekiq-cron] poller started in web process (foreman scale-to-zero mitigation)")
+    rescue => e
+      Rails.logger.error("[sidekiq-cron] failed to start web poller: #{e.class}: #{e.message}")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Applies the same fix as CruGlobal/mpdx_api#3354 to this app.

`sidekiq-cron` starts its poller **only inside Sidekiq workers** — it patches Sidekiq's server `Launcher` from within a `Sidekiq.configure_server` block, which never runs in Puma. `sidekiq-foreman` scales the Sidekiq worker fleet to `desiredCount=0` when queues are idle, and with zero workers there is no poller. For a cron-only app nothing then enqueues, `pending` stays `0`, and the foreman keeps the fleet at `0` — so cron jobs never fire. (fl-pos-admin runs sub-hourly cron, e.g. `*/30`, `*/50`.)

## Change

1. Start a `sidekiq-cron` poller in the always-on **web** process via Puma's `on_booted` hook (`config/puma.rb`). Cron keeps enqueuing regardless of worker count; once a job lands in a queue the foreman scales workers back up to run it.
   - Mirrors sidekiq-cron's server `Launcher` (sets `config[:cron_poll_interval]` before starting). Safe alongside the workers' poller (atomic `ZADD` dedup). Skips dev/test; wrapped in a rescue so a poller failure can't take down web boot.
2. Bump **oauth2 → 2.0.22** (GHSA-pp92-crg2-gfv9) to clear the pre-existing `bundle-audit` failure — conservative lockfile-only update of the oauth2 dependency family, matching the other apps in this rollout.

No Rails-EOL Brakeman ignore needed here (this app is on Rails 8.0.5, not 7.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)